### PR TITLE
Fixed bug in reading STL data on windows

### DIFF
--- a/example/map/terra_test.c
+++ b/example/map/terra_test.c
@@ -1,4 +1,4 @@
-#ifndef __unix__
+#ifdef __unix__
 #include <unistd.h>
 #endif /* __unix__ */
 #include <zeo/zeo_map.h>

--- a/include/zeo/zeo_misc.h
+++ b/include/zeo/zeo_misc.h
@@ -15,7 +15,7 @@
 __BEGIN_DECLS
 
 /*! \brief axis identifiers */
-typedef byte zAxis;
+typedef signed char zAxis;
 enum{
   zAxisInvalid=-1, zX=0, zY, zZ, zXA, zYA, zZA,
 };

--- a/src/zeo_shape3d.c
+++ b/src/zeo_shape3d.c
@@ -295,7 +295,7 @@ static void *_zShape3DImportFromZTK(void *obj, int i, void *arg, ZTK *ztk){
     obj = NULL;
 #endif
   } else{
-    if( !( fp = fopen( ZTKVal(ztk), "r" ) ) ){
+    if( !( fp = fopen( ZTKVal(ztk), "rb" ) ) ){
       ZOPENERROR( ZTKVal(ztk) );
       return NULL;
     }


### PR DESCRIPTION
The causes are the following two.  

1. The first cause was that ``fread()`` did not work correctly unless ``fopen()`` was called with the read mode as binary mode like **"r"** -> **"rb"**.  
2. The second cause was that the ``zAxis`` type of the ``split`` data type in the ``zVec3DTree`` was a **``byte``** type, and the code expected to get -1 in the initialization process, but the ``byte`` type is defined as the standard **``unsigned char``** type in Windows, and the value turned into something unexpected (255). In Linux and Unix-like RTOS environment, ``byte`` type is defined as **``signed char``** type in zeda_def.h, so -1 was taken and it worked correctly.

The fix is as follows.  

1. ``fopen()`` is modified to be executed as **"r"** -> **"rb"**.  
    ( It is confirmed that both binary type STL and ascii type STL can be read normally in **"rb"** mode on both Windows and Linux )  
2. Redefine ``zAxis`` type directly as  ``byte`` -> ``signed char`` type.

In addition, there was another bug in the macro include process in terra_test.c, which has been fixed.