### PR TITLE
Fix bball_test zMShape3DBBall() -> zMShape3DBoundingBall()

### DIFF
--- a/example/mshape/bball_test.c
+++ b/example/mshape/bball_test.c
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
 
   if( argc < 2 ) return 1;
   if( !zMShape3DReadZTK( &ms, argv[1] ) ) return 1;
-  zMShape3DBBall( &ms, &bball );
+  zMShape3DBoundingBall( &ms, &bball );
   output( &ms, &bball );
   zMShape3DDestroy( &ms );
   return 0;


### PR DESCRIPTION
As the title suggests, there is a bug that old name was used in bball_test.c, so renamed. 

Please check and merge it.