### PR TITLE
Fix vec/tree_test.c 'vmin', 'vmax' -> 'region' of zVec3DTreeData elements

### DIFF
--- a/example/vec/tree_test.c
+++ b/example/vec/tree_test.c
@@ -10,8 +10,7 @@ int main(int argc, char *argv[])
 
   zRandInit();
   zVec3DTreeInit( &tree );
-  zVec3DCreate( &tree.data.vmin, -10, -10, -10);
-  zVec3DCreate( &tree.data.vmax, 10, 10, 10 );
+  zAABox3DCreate( &tree.data.region, -10, -10, -10, 10, 10, 10 );
   for( i=0; i<N; i++ ){
     zVec3DCreate( &v, zRandF(-10,10), zRandF(-10,10), zRandF(-10,10) );
     zVec3DTreeAddPoint( &tree, &v );


### PR DESCRIPTION
As the title suggests, I have fixed a bug where the sample code could not be compiled, so please check it out.