### PR TITLE
Fixed frame/twist_test.c nurbs/nurbs_xform_test.c and pointcloud/pca_test.c

### DIFF
--- a/example/frame/twist_test.c
+++ b/example/frame/twist_test.c
@@ -10,7 +10,7 @@ int main(int argc, char *argv[])
   zVec6DCreate( &t, zRandF(-1,1), zRandF(-1,1), zRandF(-1,1), zRandF(-1,1), zRandF(-1,1), zRandF(-1,1) );
   zVec3DMulDRC( zVec6DAng(&t), zRandF(0,zPI)/zVec3DNorm(zVec6DAng(&t)) );
   /* original frame */
-  zFrame3DFromZYX( &f1, zRandF(-1,1), zRandF(-1,1), zRandF(-1,1), zRandF(-zPI,zPI), 0.5*zRandF(-zPI,zPI), zRandF(-zPI,zPI) );
+  zFrame3DFromPosZYX( &f1, zRandF(-1,1), zRandF(-1,1), zRandF(-1,1), zRandF(-zPI,zPI), 0.5*zRandF(-zPI,zPI), zRandF(-zPI,zPI) );
 
   zFrame3DTwist( &f1, &t, &f2 );
   zFrame3DError( &f2, &f1, &d );

--- a/example/nurbs/nurbs_xform_test.c
+++ b/example/nurbs/nurbs_xform_test.c
@@ -50,7 +50,7 @@ int main(void)
   nurbs_fprint( fp, &dest );
   fclose( fp );
 
-  zFrame3DFromZYX( &f, 1, 1, 1, zDeg2Rad(45), zDeg2Rad(10), zDeg2Rad(5) );
+  zFrame3DFromPosZYX( &f, 1, 1, 1, zDeg2Rad(45), zDeg2Rad(10), zDeg2Rad(5) );
   zNURBS3DXform( &src, &f, &dest );
   fp = fopen( "xfr", "w" );
   nurbs_fprint( fp, &dest );

--- a/example/pointcloud/pca_test.c
+++ b/example/pointcloud/pca_test.c
@@ -40,7 +40,7 @@ void test_vert(zVec3DData *data, double x, double y, double z, double a, double 
   int i;
 
   zVec3DDataInitArray( data, N );
-  zFrame3DFromZYX( &frame, x, y, z, zDeg2Rad(a), zDeg2Rad(b), zDeg2Rad(c) );
+  zFrame3DFromPosZYX( &frame, x, y, z, zDeg2Rad(a), zDeg2Rad(b), zDeg2Rad(c) );
   for( i=0; i<N; i++ ){
     zVec3DCreate( &v, zRandF(-wx,wx), zRandF(-wy,wy), zRandF(-wz,wz) );
     zXform3DDRC( &frame, &v );


### PR DESCRIPTION
As stated in the title, I have fixed the bugs of the three tests that had been forgotten to be updated around zFrame3DFrom*() -> zFrame3DFromPos*().